### PR TITLE
Center align items on homepage on mobile

### DIFF
--- a/src/components/EventsGrid.vue
+++ b/src/components/EventsGrid.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
 		<!--events area-->
-		<section class="bg-white py-8">
+		<section class="bg-gray-100 py-8">
 			<div class="container mx-auto flex flex-wrap pt-4">
-				<h2 class="w-full my-2 text-5xl font-bold leading-tight text-center text-gray-800">Events</h2>
+				<h2 class="w-full my-2 text-3xl md:text-5xl font-bold leading-tight text-center text-gray-800">Events</h2>
 				<div class="w-full mb-4">
 					<div class="h-1 mx-auto gradient w-64 opacity-25 my-0 py-0 rounded-t"></div>
 				</div>
@@ -11,9 +11,9 @@
 				<div
 					v-for="event in events"
 					:key="event.id"
-					class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink"
+					class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink bg-gray-100"
 				>
-					<div class="flex-1 bg-white rounded-t rounded-b-none overflow-hidden shadow">
+					<div class="flex-1 bg-white pt-8 rounded-t rounded-b-none overflow-hidden shadow">
 						<a href="#" class="flex flex-wrap no-underline hover:no-underline">
 							<p class="w-full text-gray-600 text-xs md:text-sm px-6">{{ event.date }}</p>
 							<div class="w-full font-bold text-xl text-gray-800 px-6">{{ event.title }}</div>
@@ -23,7 +23,7 @@
 					<div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden shadow p-6">
 						<div class="flex items-center justify-start">
 							<button
-								class="mx-auto lg:mx-0 hover:underline gradient text-white font-bold rounded-full my-6 py-4 px-8 shadow-lg"
+								class="mx-auto w-full md:w-auto lg:mx-0 hover:underline gradient text-white font-bold rounded-full py-4 px-8 shadow-lg"
 							>
 								Register
 							</button>
@@ -33,8 +33,8 @@
 			</div>
 		</section>
 
-		<section class="bg-white">
-			<h2 class="w-full text-5xl font-bold leading-tight text-center text-gray-800">Women Teaching Women</h2>
+		<section class="bg-gray-100">
+			<h2 class="w-full text-3xl md:text-5xl font-bold leading-tight text-center text-gray-800">Women Teaching Women</h2>
 			<div class="w-full mb-4">
 				<div class="h-1 mx-auto gradient w-64 opacity-25 my-3 py-0 rounded-t"></div>
 			</div>
@@ -95,12 +95,12 @@
 		</svg>
 
 		<section class="container mx-auto text-center py-6 mb-12">
-			<h2 class="w-full my-2 text-5xl font-bold leading-tight text-center text-white">Come Skulk with Us</h2>
+			<h2 class="w-full my-2 text-3xl md:text-5xl font-bold leading-tight text-center text-white">Come Skulk with Us</h2>
 			<div class="w-full mb-4">
 				<div class="h-1 mx-auto bg-white w-1/6 opacity-25 my-0 py-0 rounded-t"></div>
 			</div>
 
-			<h3 class="my-4 text-3xl leading-tight">Our workshops are always free</h3>
+			<h3 class="my-4 text-xl md:text-3xl leading-tight">Our workshops are always free</h3>
 		</section>
 	</div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,14 +4,14 @@
 		<div class="pt-24">
 			<div class="container px-3 mx-auto flex flex-wrap flex-col md:flex-row">
 				<!--Left Col-->
-				<div class="flex flex-col w-full md:w-2/5">
-					<h1 class="my-4 text-5xl font-bold leading-tight">Welcome!</h1>
-					<p class="leading-normal text-4xl mb-8">
+				<div class="flex flex-col w-full md:w-2/5 text-center md:text-left">
+					<h1 class="my-4 text-3xl md:text-5xl font-bold leading-tight">Welcome!</h1>
+					<p class="leading-normal text-2xl md:text-4xl mb-8">
 						Front-End Foxes are women who want to learn front-end technologies to make websites and mobile
 						apps
 					</p>
 
-					<div class="flex">
+					<div class="flex justify-center md:justify-start z-10">
 						<a
 							class="bg-orange-700 mr-5 text-white font-bold uppercase rounded my-6 py-4 px-8 shadow-lg"
 							to="https://www.patreon.com"
@@ -43,7 +43,7 @@
 				xmlns:xlink="http://www.w3.org/1999/xlink"
 			>
 				<g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-					<g transform="translate(-2.000000, 44.000000)" fill="#FFFFFF" fill-rule="nonzero">
+					<g transform="translate(-2.000000, 44.000000)" fill="#f7fafc" fill-rule="nonzero">
 						<path
 							d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496"
 							opacity="0.100000001"
@@ -58,7 +58,7 @@
 							opacity="0.200000003"
 						/>
 					</g>
-					<g transform="translate(-4.000000, 76.000000)" fill="#FFFFFF" fill-rule="nonzero">
+					<g transform="translate(-4.000000, 76.000000)" fill="#f7fafc" fill-rule="nonzero">
 						<path
 							d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"
 						/>


### PR DESCRIPTION
I made a number of edits as well as centre aligning the items on the homepage on mobile... they're not extensive and at the moment are only on the homepage, let me know if these are okay and I'm happy to roll out across the site and/or take the changes a bit further. Happy to discuss.

Changes:
* Items on page are centre aligned
* Font on the homepage is now slightly smaller on mobile sizes so that we don’t get stranded words from headings on one line
* Increase the z-index of the buttons so they sit in front of the the wave SVGs
* Made the background a light blue-grey behind the events to make them pop more
* Increased the padding above the date on the events on the homepage
* Event buttons take up full width on mobile now

Fixes #3